### PR TITLE
Added participating POAP count and link to POAP collection

### DIFF
--- a/frontend/src/ui/components/RaffleParticipants.tsx
+++ b/frontend/src/ui/components/RaffleParticipants.tsx
@@ -120,7 +120,7 @@ const OtherParticipants = styled.div`
 const maxParticipantsAmount = 200;
 
 const ParticipantNumbers: FC<ParticipantNumbersProps> = ({ participants }) => {
-  const generateLinks = (token: number) => {
+  const generateLinks = (token: number, address: string) => {
     return (
       <PopoverContent>
         <div>
@@ -131,6 +131,11 @@ const ParticipantNumbers: FC<ParticipantNumbersProps> = ({ participants }) => {
         <div>
           <a href={endpoints.poap.token(token)} target="_blank" rel="noopener noreferrer">
             View on POAP <FiExternalLink />
+          </a>
+        </div>
+        <div>
+          <a href={endpoints.poap.webScan(address)} target="_blank" rel="noopener noreferrer">
+            View POAP collection <FiExternalLink />
           </a>
         </div>
       </PopoverContent>
@@ -146,7 +151,12 @@ const ParticipantNumbers: FC<ParticipantNumbersProps> = ({ participants }) => {
         {_participants.map((each) => {
           return (
             <Tooltip title={each.event.name} key={each.id}>
-              <Popover placement={'bottom'} title={''} content={generateLinks(each.poap_id)} trigger={['click']}>
+              <Popover
+                placement={'bottom'}
+                title={''}
+                content={generateLinks(each.poap_id, each.address)}
+                trigger={['click']}
+              >
                 <div className="number-container">
                   <img src={each.event.image_url} alt={each.event.name} />
                   <span>
@@ -206,7 +216,7 @@ const RaffleParticipants: FC<RaffleParticipantsProps> = ({ participants, isLoadi
   return (
     <Spin spinning={isLoading} tip="Loading participants">
       <Content>
-        <Title>Participating POAPs</Title>
+        <Title>Participating POAPs - {accountTickets.length + otherTickets.length}</Title>
         <div className={'participant-box'}>
           {accountTickets.length > 0 && (
             <div>


### PR DESCRIPTION
## What's new?
Hey all - I've hosted a few POAP.fun raffles and love it :)  I've noticed two small enhancements that could improve the experience so I wanted to send over a PR for possible inclusion in case they are features you see as useful too.  No worries if not - you may have reasons for not having included them already, so no hard feelings if you don't merge.

1. Count for participating POAPs. I find frequently we scroll and try to estimate how many have jumped in.
2. A third link to the links that appear when you click on a POAP that leads straight to that holder's collection.  Frequently on calls Patricio or I will try to identify the person based on their POAP collection, but it is a few clicks to get there.

## Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ X ] New feature (non-breaking change that adds functionality)

## Test steps to reproduce

I tested it for the following cases:
 - Raffle with no participating POAPs
 - Raffle with participating POAPs, but the user is not one
 - Raffle with participating POAPs, and the user *is* one

Also, I tested the third (direct to POAP collection) link for both a POAP that was mine, and one that was not.

## Gif / Screenshots

![Screen Shot 2021-04-29 at 4 46 58 PM](https://user-images.githubusercontent.com/914240/116616878-31ca2d80-a90b-11eb-90d5-372c320e4d43.png)

![Screen Shot 2021-04-29 at 4 47 34 PM](https://user-images.githubusercontent.com/914240/116616915-3ee71c80-a90b-11eb-8e70-3cae87b0cfb3.png)
