### PR TITLE
Add ENS to Participating POAPs Display

### DIFF
--- a/frontend/src/ui/components/RaffleParticipants.tsx
+++ b/frontend/src/ui/components/RaffleParticipants.tsx
@@ -36,7 +36,7 @@ const Content = styled.div`
   padding: 30px 0;
 
   @media (min-width: ${BREAKPOINTS.sm}) {
-    padding: 30px 100px;
+    padding: 30px 50px;
   }
 
   .participant-box {
@@ -48,6 +48,7 @@ const Content = styled.div`
       display: flex;
       align-items: center;
       flex-direction: column;
+      margin-bottom: 10px;
 
       img {
         width: 60px;
@@ -73,8 +74,12 @@ const Content = styled.div`
       max-width: 500px;
       cursor: pointer;
 
+      @media (max-width: ${BREAKPOINTS.sm}) {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }
+
       @media (max-width: ${BREAKPOINTS.xs}) {
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
       }
 
       div {
@@ -119,6 +124,10 @@ const OtherParticipants = styled.div`
 
 const maxParticipantsAmount = 200;
 
+// Utils
+const shortAddress = (address: string) => `${address.slice(0, 6)}...${address.slice(-4)}`;
+const shortEns = (ens: string) => `${ens.length > 15 ? ens.substr(0, 14) + '...' : ens}`;
+
 const ParticipantNumbers: FC<ParticipantNumbersProps> = ({ participants }) => {
   const generateLinks = (token: number, address: string) => {
     return (
@@ -159,6 +168,7 @@ const ParticipantNumbers: FC<ParticipantNumbersProps> = ({ participants }) => {
               >
                 <div className="number-container">
                   <img src={each.event.image_url} alt={each.event.name} />
+                  <span>{each.ens_name ? shortEns(each.ens_name) : shortAddress(each.address)}</span>
                   <span>
                     #{each.poap_id.toString().padStart(5, '0')} <FiExternalLink />{' '}
                   </span>


### PR DESCRIPTION
## What's new?
Hey team, a small enhancement for you :)

I added the POAP holder's ens/address to the Participating POAPs view.  It made each a little wider/taller so I had to tweak the spacing a little bit, let me know if you have any feedback.  Also I am very open to feedback on my CSS changes, etc so let me know if you'd like anything changed/updated.  Some screenshots below of the enhancement and at different media breakpoints.

## Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)

## Test steps to reproduce

Bring up a raffle that has not been drawn yet and take a look at the Participating POAPs section

## Gif / Screenshots

Full view:
<img width="787" alt="Screen Shot 2021-06-01 at 10 52 29 AM" src="https://user-images.githubusercontent.com/914240/120370715-f2fd0e00-c2e2-11eb-948c-06baa27cd11e.png">

Various smaller views:
<img width="775" alt="Screen Shot 2021-06-01 at 10 52 45 AM" src="https://user-images.githubusercontent.com/914240/120370726-f5f7fe80-c2e2-11eb-8751-7935d4a446a1.png">
<img width="502" alt="Screen Shot 2021-06-01 at 10 53 02 AM" src="https://user-images.githubusercontent.com/914240/120370730-f6909500-c2e2-11eb-80d1-9aac8af2a225.png">
<img width="485" alt="Screen Shot 2021-06-01 at 10 53 11 AM" src="https://user-images.githubusercontent.com/914240/120370734-f7292b80-c2e2-11eb-83c5-c24e1c4b072d.png">

Truncated ENS:
<img width="323" alt="Screen Shot 2021-06-01 at 10 53 50 AM" src="https://user-images.githubusercontent.com/914240/120370737-f7c1c200-c2e2-11eb-93fe-73408fa675be.png">
