### PR TITLE
Add support for Metamask EIP712 signature for Ledger wallets

### DIFF
--- a/backend/core/services/_poap_integration_service.py
+++ b/backend/core/services/_poap_integration_service.py
@@ -70,6 +70,9 @@ class PoapIntegrationService:
             s = '0x' + signature[64: 128]
             v = int(signature[128: 130], 16)
 
+            if v == 0 or v == 1:
+                v = v + 27
+
             signer = contract.functions.verify([Web3.toChecksumAddress(address.lower()), raffle_id], r, s, v).call()
             logger.info(f"INFO >> Signature validation >> Comparing: {signer.lower()} vs {address.lower()}")
             return address.lower() == signer.lower()


### PR DESCRIPTION
## What's new?
- Signature's `v` was always send as `27` or `28`, but from Ledger was `0` or `1`. So a simple fix was added for this cases.

After several tests, the backend could validate the correct signer
