### PR TITLE
Use gasUsed instead of gasLimit

### DIFF
--- a/backend/core/services/_raffle_results_service.py
+++ b/backend/core/services/_raffle_results_service.py
@@ -53,7 +53,7 @@ class RaffleResultsService:
         return remaining_participants
 
     @classmethod
-    def _split_by_gas_limit(cls, gas_limit, participants):
+    def _split_by_gas_used(cls, gas_used, participants):
 
         if not participants:
             return None
@@ -67,12 +67,12 @@ class RaffleResultsService:
         while not valid_split:
             prev_iteration_digit = None
             comparing_digits_identical = True
-            gas_limit_last_digit = gas_limit % 10
+            gas_used_last_digit = gas_used % 10
             for participant in participants:
                 poap_id = participant.poap_id
                 poap_id_cmp_digit = math.floor(poap_id/order) % 10
 
-                if poap_id_cmp_digit == gas_limit_last_digit:
+                if poap_id_cmp_digit == gas_used_last_digit:
                     eliminated_participants.append(participant)
                 else:
                     remaining_participants.append(participant)
@@ -133,7 +133,7 @@ class RaffleResultsService:
             send_has_ended_raffle_notifications.delay(results_table.raffle.id)
             return True
 
-        eliminated_participants = cls._split_by_gas_limit(block_data.gas_limit, participants)
+        eliminated_participants = cls._split_by_gas_used(block_data.gas_used, participants)
 
         # calculate the starting order
         order = len(participants) - len(eliminated_participants)
@@ -183,12 +183,12 @@ class RaffleResultsService:
 
         next_block_number = raw_block_data.get("number")
         next_block_timestamps = raw_block_data.get("timestamp")
-        next_gas_limit = raw_block_data.get("gasLimit")
+        next_gas_used = raw_block_data.get("gasUsed")
         q = BlockData.objects.filter(
             raffle=raffle,
             block_number=next_block_number,
             timestamp=next_block_timestamps,
-            gas_limit=next_gas_limit
+            gas_used=next_gas_used
         )
         if q.exists():
             return None
@@ -196,7 +196,7 @@ class RaffleResultsService:
         order = prev_block.order + 1 if prev_block else 0
         block_data = BlockData(
             raffle=raffle,
-            gas_limit=next_gas_limit,
+            gas_used=next_gas_used,
             block_number=next_block_number,
             timestamp=next_block_timestamps,
             order=order


### PR DESCRIPTION
## What's new?
- To speed up raffles, the last digit of gas used in a block should have more variety than the block gas limit

## Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
