### PR TITLE
Fix lock raffles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ pylint:
 py-tests:
 	@echo "Running python tests"
 	docker exec $(WEB) /bin/sh -c "coverage run --source='.' manage.py test"
+	docker exec $(WEB) /bin/sh -c "pytest"
 
 test-all:
 	@echo "Running all tests"

--- a/backend/core/services/_raffle_results_service.py
+++ b/backend/core/services/_raffle_results_service.py
@@ -178,7 +178,7 @@ class RaffleResultsService:
                 raw_block_data = w3.eth.getBlock(prev_block.block_number+1)
             else:
                 raw_block_data = w3.eth.getBlock('latest')
-        except BlockNotFound:
+        except Exception:
             return None
 
         next_block_number = raw_block_data.get("number")

--- a/backend/core/services/_raffle_results_service.py
+++ b/backend/core/services/_raffle_results_service.py
@@ -4,10 +4,11 @@ from typing import List, Optional
 
 from django.db import transaction
 from web3.auto import w3
-from web3.exceptions import BlockNotFound
 
 from core.models import Raffle, Participant, ResultsTable, BlockData, ResultsTableEntry
 from notifications.tasks import send_has_ended_raffle_notifications
+
+logger = logging.getLogger("RaffleResultService")
 
 
 class RaffleResultsService:
@@ -179,6 +180,7 @@ class RaffleResultsService:
             else:
                 raw_block_data = w3.eth.getBlock('latest')
         except Exception:
+            logger.warning(f"Error: {str(e)} raffle with id {raffle_id}")
             return None
 
         next_block_number = raw_block_data.get("number")

--- a/backend/core/services/_raffle_results_service.py
+++ b/backend/core/services/_raffle_results_service.py
@@ -181,7 +181,7 @@ class RaffleResultsService:
             else:
                 raw_block_data = w3.eth.getBlock('latest')
         except Exception as e:
-            logger.warning(f"Error: {str(e)} raffle with id {raffle_id}")
+            logger.warning(f"Error: {str(e)} raffle with id {raffle.id}")
             return None
 
         next_block_number = raw_block_data.get("number")

--- a/backend/core/services/_raffle_results_service.py
+++ b/backend/core/services/_raffle_results_service.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from datetime import datetime
 from typing import List, Optional
@@ -179,7 +180,7 @@ class RaffleResultsService:
                 raw_block_data = w3.eth.getBlock(prev_block.block_number+1)
             else:
                 raw_block_data = w3.eth.getBlock('latest')
-        except Exception:
+        except Exception as e:
             logger.warning(f"Error: {str(e)} raffle with id {raffle_id}")
             return None
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -21,6 +21,9 @@ def generate_raffle_results_task(raffle_id):
 
     db_lock.lock()
 
-    raffle_results_service.generate_next_result_step(raffle)
+    try:
+        raffle_results_service.generate_next_result_step(raffle)
+    except Exception as e:
+        logger.warning(f"Error: {str(e)} raffle with id {raffle_id}")
 
     db_lock.unlock()

--- a/backend/core/tests/test_fixtures.py
+++ b/backend/core/tests/test_fixtures.py
@@ -54,7 +54,6 @@ def raffle_with_participants():
     RaffleWithParticipants = collections.namedtuple('RaffleWithParticipants', 'raffle remaining_participants')
     raffle = baker.make('core.Raffle')
     participants = baker.make('core.Participant', raffle=raffle, _quantity=6)
-    results_table = baker.make('core.ResultsTable', raffle=raffle)
 
     fixed_participants = participants[:3]
     remaining_participants = participants[3:]
@@ -63,7 +62,7 @@ def raffle_with_participants():
         table_entry = baker.make(
             'core.ResultsTableEntry',
             participant=participant,
-            results_table=results_table,
+            results_table=raffle.results_table,
             order=order
         )
         order -= 1

--- a/backend/core/tests/test_models.py
+++ b/backend/core/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from django.utils import timezone
 
 from django.test import TestCase
 
@@ -11,8 +11,8 @@ class RaffleTestCase(TestCase):
         self.name = 'raffle name'
         self.description = 'raffle description'
         self.contact = 'test@email.com'
-        self.draw_datetime = datetime.now()
-        self.end_datetime = datetime.now()
+        self.draw_datetime = timezone.now()
+        self.end_datetime = timezone.now()
         self.one_address_one_vote = True
         self.raffle = Raffle.objects.create(
             name=self.name,

--- a/backend/core/tests/test_services.py
+++ b/backend/core/tests/test_services.py
@@ -17,7 +17,6 @@ class TestRaffleResultsService:
     @pytest.mark.django_db
     def test_remaining_participants_ordering(self):
         raffle = baker.make('core.Raffle', one_address_one_vote=False)
-        baker.make('core.ResultsTable', raffle=raffle)
         participant_1 = baker.make(
             'core.Participant', raffle=raffle, address="0x1", poap_id=11239
         )
@@ -43,7 +42,6 @@ class TestRaffleResultsService:
     @pytest.mark.django_db
     def test_remaining_participants_ordering_one_address_one_vote(self):
         raffle = baker.make('core.Raffle', one_address_one_vote=True)
-        baker.make('core.ResultsTable', raffle=raffle)
         participant_1 = baker.make(
             'core.Participant', raffle=raffle, address="0x1", poap_id=11239
         )
@@ -69,7 +67,6 @@ class TestRaffleResultsService:
     @pytest.mark.django_db
     def test_save_new_results_table_entries(self):
         raffle = baker.make('core.Raffle')
-        baker.make('core.ResultsTable', raffle=raffle)
         participant_1 = baker.make(
             'core.Participant', raffle=raffle, address="0x1", poap_id=109
         )
@@ -106,7 +103,6 @@ class TestRaffleResultsService:
     @pytest.mark.django_db
     def test_save_new_results_table_entries_empty_slash(self):
         raffle = baker.make('core.Raffle')
-        baker.make('core.ResultsTable', raffle=raffle)
         participant_1 = baker.make(
             'core.Participant', raffle=raffle, address="0x1", poap_id=124
         )
@@ -126,7 +122,6 @@ class TestRaffleResultsService:
     @pytest.mark.django_db
     def test_raffle_finalization(self):
         raffle = baker.make('core.Raffle', one_address_one_vote=False)
-        baker.make('core.ResultsTable', raffle=raffle)
         participant_1 = baker.make(
             'core.Participant', raffle=raffle, address="0x1", poap_id=124
         )


### PR DESCRIPTION
## Summary

POAP Raffles are being locked do to an error when calling ethers to get the last block. This error was not handled appropriately and raffles end up being locked forever because the lock wasn't released 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1062" alt="Screenshot 2022-04-09 at 2 38 54 PM" src="https://user-images.githubusercontent.com/19600590/162632254-01ffa67b-af79-4204-a742-1505c0ae3063.png">


## Testing

You can run all the project and create a raffle or you can enter the shell import the function and try different scenarios like throwing an error in an inner function and see how it handles the exceptions

## Ticket

[PLT-168](https://poap-devs.atlassian.net/browse/PLT-188)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I didn't commit unnecessary logs
